### PR TITLE
change ordering of initialization to fix an annoying log message

### DIFF
--- a/ainit/dump.go
+++ b/ainit/dump.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -14,35 +13,28 @@ import (
 	"github.com/lthummus/auththingie2/config"
 )
 
-var (
-	initOnce = sync.Once{}
-)
-
-func InitLogger(useColor bool) {
-	initOnce.Do(func() {
-		var revision string
-		info, _ := debug.ReadBuildInfo()
-		for i := range info.Settings {
-			if info.Settings[i].Key == "vcs.revision" {
-				revision = info.Settings[i].Value
-				break
-			}
+func init() {
+	var revision string
+	info, _ := debug.ReadBuildInfo()
+	for i := range info.Settings {
+		if info.Settings[i].Key == "vcs.revision" {
+			revision = info.Settings[i].Value
+			break
 		}
+	}
 
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339, NoColor: !useColor})
-		log.Info().
-			Str("arch", runtime.GOARCH).
-			Str("os", runtime.GOOS).
-			Str("go_version", strings.TrimPrefix(runtime.Version(), "go")).
-			Str("git_commit", revision).
-			Msg("hello world")
-		if !config.IsProductionMode() || config.IsDebugLoggingEnabled() {
-			zerolog.SetGlobalLevel(zerolog.TraceLevel)
-			log.Warn().Str("environment", os.Getenv("ENVIRONMENT")).Bool("docker_detected", config.IsDocker()).Msg("starting with debug logging enabled")
-		} else {
-			zerolog.SetGlobalLevel(zerolog.InfoLevel)
-			log.Info().Str("environment", os.Getenv("ENVIRONMENT")).Bool("docker_detected", config.IsDocker()).Msg("starting in production mode")
-		}
-	})
-
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
+	log.Info().
+		Str("arch", runtime.GOARCH).
+		Str("os", runtime.GOOS).
+		Str("go_version", strings.TrimPrefix(runtime.Version(), "go")).
+		Str("git_commit", revision).
+		Msg("hello world")
+	if !config.IsProductionMode() || config.IsDebugLoggingEnabled() {
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+		log.Warn().Str("environment", os.Getenv("ENVIRONMENT")).Bool("docker_detected", config.IsDocker()).Msg("starting with debug logging enabled")
+	} else {
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		log.Info().Str("environment", os.Getenv("ENVIRONMENT")).Bool("docker_detected", config.IsDocker()).Msg("starting in production mode")
+	}
 }

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/lthummus/auththingie2/ainit"
 	"github.com/lthummus/auththingie2/config"
 	"github.com/lthummus/auththingie2/healthcheck"
 )
@@ -33,7 +32,6 @@ var healthCheckCmd = &cobra.Command{
 	Long: "checks the health of a running auththingie2 instance. This is best used as a " +
 		"defined healthcheck inside a docker container",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ainit.InitLogger(false)
 		if !useConfig && host == "" {
 			return fmt.Errorf("auththingie2: healthcheck: one of useconfig host must be specified")
 		}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "github.com/lthummus/auththingie2/ainit"
 	"github.com/lthummus/auththingie2/cmd"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/lthummus/auththingie2/loginlimit"
 	"net/http"
 	"os"
 	"os/signal"
 	"sync"
 	"time"
 
+	"github.com/lthummus/auththingie2/loginlimit"
+
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 
-	"github.com/lthummus/auththingie2/ainit"
 	"github.com/lthummus/auththingie2/config"
 	"github.com/lthummus/auththingie2/db/sqlite"
 	"github.com/lthummus/auththingie2/ftue"
@@ -26,7 +26,6 @@ import (
 )
 
 func RunServer() {
-	ainit.InitLogger(true)
 	render.Init()
 
 	err := config.Init()


### PR DESCRIPTION
Fix the fact that the hash for timing attack prevention happens before log initialization which causes inconsistent log formatting. It's a small aesthetic thing, but it annoys me