### PR TITLE
full reset account lock state on success

### DIFF
--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -180,6 +180,9 @@ func (e *Env) handleLoginPost(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
+	e.LoginLimiter.MarkSuccessfulAttempt(sourceIPKey)
+	e.LoginLimiter.MarkSuccessfulAttempt(accountKey)
+
 	if u.TOTPEnabled() {
 		loginTicket := totp.GenerateLoginTicket(u.Id, redirectURL)
 		e.handleTotpPrompt(w, r, loginTicket, "")

--- a/internal/handlers/login_test.go
+++ b/internal/handlers/login_test.go
@@ -313,6 +313,8 @@ func TestEnv_HandleLoginPage(t *testing.T) {
 
 		ll.On("IsAccountLocked", "ip|192.0.2.1").Return(false)
 		ll.On("IsAccountLocked", "username|regularuser").Return(false)
+		ll.On("MarkSuccessfulAttempt", "username|regularuser")
+		ll.On("MarkSuccessfulAttempt", "ip|192.0.2.1")
 		db.On("GetUserByUsername", mock.Anything, "regularuser").Return(sampleDisabledUser, nil)
 
 		r := makeTestRequest(t, http.MethodPost, "/login", strings.NewReader(v.Encode()))
@@ -336,6 +338,8 @@ func TestEnv_HandleLoginPage(t *testing.T) {
 
 		ll.On("IsAccountLocked", "ip|192.0.2.1").Return(false)
 		ll.On("IsAccountLocked", "username|regularuser").Return(false)
+		ll.On("MarkSuccessfulAttempt", "ip|192.0.2.1")
+		ll.On("MarkSuccessfulAttempt", "username|regularuser")
 		db.On("GetUserByUsername", mock.Anything, "regularuser").Return(sampleDisabledUserWithTOTP, nil)
 
 		r := makeTestRequest(t, http.MethodPost, "/login", strings.NewReader(v.Encode()))
@@ -365,6 +369,8 @@ func TestEnv_HandleLoginPage(t *testing.T) {
 
 		ll.On("IsAccountLocked", "ip|192.0.2.1").Return(false)
 		ll.On("IsAccountLocked", "username|regularuser").Return(false)
+		ll.On("MarkSuccessfulAttempt", "ip|192.0.2.1")
+		ll.On("MarkSuccessfulAttempt", "username|regularuser")
 		db.On("GetUserByUsername", mock.Anything, "regularuser").Return(sampleNonAdminUser, nil)
 
 		r := makeTestRequest(t, http.MethodPost, "/login", strings.NewReader(v.Encode()))
@@ -399,6 +405,8 @@ func TestEnv_HandleLoginPage(t *testing.T) {
 
 		ll.On("IsAccountLocked", "ip|192.0.2.1").Return(false)
 		ll.On("IsAccountLocked", "username|regularuser").Return(false)
+		ll.On("MarkSuccessfulAttempt", "ip|192.0.2.1")
+		ll.On("MarkSuccessfulAttempt", "username|regularuser")
 		db.On("GetUserByUsername", mock.Anything, "regularuser").Return(sampleNonAdminUser, nil)
 
 		r := makeTestRequest(t, http.MethodPost, "/login", strings.NewReader(v.Encode()))
@@ -430,6 +438,8 @@ func TestEnv_HandleLoginPage(t *testing.T) {
 
 		ll.On("IsAccountLocked", "ip|192.0.2.1").Return(false)
 		ll.On("IsAccountLocked", "username|sampletotp").Return(false)
+		ll.On("MarkSuccessfulAttempt", "ip|192.0.2.1")
+		ll.On("MarkSuccessfulAttempt", "username|sampletotp")
 		db.On("GetUserByUsername", mock.Anything, "sampletotp").Return(sampleNonAdminWithTOTP, nil)
 
 		r := makeTestRequest(t, http.MethodPost, "/login", strings.NewReader(v.Encode()))
@@ -461,6 +471,8 @@ func TestEnv_HandleLoginPage(t *testing.T) {
 
 		ll.On("IsAccountLocked", "ip|192.0.2.1").Return(false)
 		ll.On("IsAccountLocked", "username|oldpwuser").Return(false)
+		ll.On("MarkSuccessfulAttempt", "ip|192.0.2.1")
+		ll.On("MarkSuccessfulAttempt", "username|oldpwuser")
 		db.On("GetUserByUsername", mock.Anything, "oldpwuser").Return(sampleNonAdminWithOldArgonParams, nil)
 		db.On("UpdatePassword", mock.Anything, mock.AnythingOfType("*user.User")).Return(nil)
 

--- a/internal/handlers/totp.go
+++ b/internal/handlers/totp.go
@@ -125,6 +125,8 @@ func (e *Env) handleTotpValidate(w http.ResponseWriter, r *http.Request, data to
 		return
 	}
 
+	e.LoginLimiter.MarkSuccessfulAttempt(sourceIPKey)
+
 	if user.Disabled {
 		log.Warn().Str("ip", trueip.Find(r)).Str("username", user.Username).Msg("attempted login of disabled account")
 		e.handleTotpPrompt(w, r, data, "Account is disabled")

--- a/internal/handlers/totp_test.go
+++ b/internal/handlers/totp_test.go
@@ -238,6 +238,7 @@ func TestEnv_HandleTOTPValidation(t *testing.T) {
 		_, db, ll, e := makeTestEnv(t)
 
 		ll.On("IsAccountLocked", "totp_ip|192.0.2.1").Return(false)
+		ll.On("MarkSuccessfulAttempt", "totp_ip|192.0.2.1")
 		db.On("GetUserByGuid", mock.Anything, "test-user").Return(&user.User{
 			Id:       "test-user",
 			Username: "testuser",
@@ -275,6 +276,7 @@ func TestEnv_HandleTOTPValidation(t *testing.T) {
 		_, db, ll, e := makeTestEnv(t)
 
 		ll.On("IsAccountLocked", "totp_ip|192.0.2.1").Return(false)
+		ll.On("MarkSuccessfulAttempt", "totp_ip|192.0.2.1")
 		db.On("GetUserByGuid", mock.Anything, "test-user").Return(&user.User{
 			Id:       "test-user",
 			Username: "testuser",
@@ -305,6 +307,7 @@ func TestEnv_HandleTOTPValidation(t *testing.T) {
 		_, db, ll, e := makeTestEnv(t)
 
 		ll.On("IsAccountLocked", "totp_ip|192.0.2.1").Return(false)
+		ll.On("MarkSuccessfulAttempt", "totp_ip|192.0.2.1")
 		db.On("GetUserByGuid", mock.Anything, "test-user").Return(&user.User{
 			Id:       "test-user",
 			Username: "testuser",

--- a/internal/mocks/LoginLimiter.go
+++ b/internal/mocks/LoginLimiter.go
@@ -145,3 +145,43 @@ func (_c *MockLoginLimiter_MarkFailedAttempt_Call) RunAndReturn(run func(key str
 	_c.Call.Return(run)
 	return _c
 }
+
+// MarkSuccessfulAttempt provides a mock function for the type MockLoginLimiter
+func (_mock *MockLoginLimiter) MarkSuccessfulAttempt(key string) {
+	_mock.Called(key)
+	return
+}
+
+// MockLoginLimiter_MarkSuccessfulAttempt_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkSuccessfulAttempt'
+type MockLoginLimiter_MarkSuccessfulAttempt_Call struct {
+	*mock.Call
+}
+
+// MarkSuccessfulAttempt is a helper method to define mock.On call
+//   - key string
+func (_e *MockLoginLimiter_Expecter) MarkSuccessfulAttempt(key interface{}) *MockLoginLimiter_MarkSuccessfulAttempt_Call {
+	return &MockLoginLimiter_MarkSuccessfulAttempt_Call{Call: _e.mock.On("MarkSuccessfulAttempt", key)}
+}
+
+func (_c *MockLoginLimiter_MarkSuccessfulAttempt_Call) Run(run func(key string)) *MockLoginLimiter_MarkSuccessfulAttempt_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockLoginLimiter_MarkSuccessfulAttempt_Call) Return() *MockLoginLimiter_MarkSuccessfulAttempt_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockLoginLimiter_MarkSuccessfulAttempt_Call) RunAndReturn(run func(key string)) *MockLoginLimiter_MarkSuccessfulAttempt_Call {
+	_c.Run(run)
+	return _c
+}


### PR DESCRIPTION
When a user successfully logs in, reset all failures in the login limiter for user ergonomics 