### PR TITLE
Optimizations and no query matching

### DIFF
--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -69,12 +69,15 @@ func (e *Env) HandleTestRule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	path, query := rules.NormalizeURI(parsedURL.EscapedPath())
+
 	ri := &rules.RequestInfo{
-		Method:     http.MethodGet,
-		Protocol:   parsedURL.Scheme,
-		Host:       rules.NormalizeHost(parsedURL.Host),
-		RequestURI: rules.NormalizeURI(parsedURL.EscapedPath()),
-		SourceIP:   source,
+		Method:      http.MethodGet,
+		Protocol:    parsedURL.Scheme,
+		Host:        rules.NormalizeHost(parsedURL.Host),
+		RequestURI:  path,
+		QueryString: query,
+		SourceIP:    source,
 	}
 
 	rule := e.Analyzer.MatchesRule(ri)

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -69,14 +69,14 @@ func (e *Env) HandleTestRule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path, query := rules.NormalizeURI(parsedURL.EscapedPath())
+	path, _ := rules.NormalizeURI(parsedURL.EscapedPath())
 
 	ri := &rules.RequestInfo{
 		Method:      http.MethodGet,
 		Protocol:    parsedURL.Scheme,
 		Host:        rules.NormalizeHost(parsedURL.Host),
 		RequestURI:  path,
-		QueryString: query,
+		QueryString: parsedURL.RawQuery,
 		SourceIP:    source,
 	}
 

--- a/internal/handlers/forward.go
+++ b/internal/handlers/forward.go
@@ -36,12 +36,16 @@ func pullInfoFromRequest(r *http.Request) rules.RequestInfo {
 	// one little note -- we get the source IP from the X-Forwarded-For header naively here. This is ok because the
 	// forward auth request is a separate, constructed one from Traefik that we can trust and it is not a proxied request
 	// we have to view with suspicion
+
+	path, query := rules.NormalizeURI(r.Header.Get(requestURIHeader))
+
 	return rules.RequestInfo{
-		Method:     r.Header.Get(httpMethodHeader),
-		Protocol:   strings.ToLower(r.Header.Get(protocolHeader)),
-		Host:       rules.NormalizeHost(r.Header.Get(hostHeader)),
-		RequestURI: rules.NormalizeURI(r.Header.Get(requestURIHeader)),
-		SourceIP:   net.ParseIP(r.Header.Get(sourceIPAddressHeader)),
+		Method:      r.Header.Get(httpMethodHeader),
+		Protocol:    strings.ToLower(r.Header.Get(protocolHeader)),
+		Host:        rules.NormalizeHost(r.Header.Get(hostHeader)),
+		RequestURI:  path,
+		QueryString: query,
+		SourceIP:    net.ParseIP(r.Header.Get(sourceIPAddressHeader)),
 	}
 }
 

--- a/internal/handlers/forward_test.go
+++ b/internal/handlers/forward_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -104,6 +105,26 @@ func TestEnv_HandleAccountDisabled(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 		assert.Contains(t, w.Body.String(), "Your account has been disabled. You are currently logged in as <strong>sample-user</strong>")
 	})
+}
+
+func TestPullInfoFromRequest(t *testing.T) {
+	h := http.Header{}
+	h.Add(httpMethodHeader, "GET")
+	h.Add(protocolHeader, "https")
+	h.Add(hostHeader, "download.example.com")
+	h.Add(requestURIHeader, "/somepage.html?foo=bar")
+	h.Add(sourceIPHeader, "10.0.0.1")
+	r, _ := http.NewRequest(http.MethodGet, "/check", nil)
+	r.Header = h
+
+	ri := pullInfoFromRequest(r)
+
+	assert.Equal(t, "GET", ri.Method)
+	assert.Equal(t, "https", ri.Protocol)
+	assert.Equal(t, "download.example.com", ri.Host)
+	assert.Equal(t, "/somepage.html", ri.RequestURI)
+	assert.Equal(t, "foo=bar", ri.QueryString)
+	assert.Equal(t, net.ParseIP("10.0.0.1"), ri.SourceIP)
 }
 
 func TestEnv_HandleNotAllowed(t *testing.T) {

--- a/internal/rules/analyzer.go
+++ b/internal/rules/analyzer.go
@@ -29,7 +29,7 @@ type Analyzer interface {
 
 var (
 	ruleFieldOrder = []string{"name",
-		"source",
+		"source_address",
 		"protocol_pattern",
 		"host_pattern",
 		"path_pattern",
@@ -110,18 +110,23 @@ func (a *ViperConfigAnalyzer) UpdateFromConfigFile() error {
 	var ruleNames []string
 
 	a.rules = nil
-	parsedRules := make([]Rule, len(rules))
-	for i, curr := range rules {
+	parsedRules := make([]Rule, 0, len(rules))
+	for _, curr := range rules {
 		r, err := curr.ToRule()
 		if err != nil {
 			a.errors = append(a.errors, fmt.Sprintf("could not parse rule: %s", err.Error()))
 		} else {
-			parsedRules[i] = *r
+			parsedRules = append(parsedRules, *r)
 			ruleNames = append(ruleNames, r.Name)
-			for _, curr := range r.PermittedRoles {
-				knownRoleSet[curr] = true
+			for _, role := range r.PermittedRoles {
+				knownRoleSet[role] = true
 			}
 		}
+	}
+
+	if len(a.errors) > 0 {
+		log.Error().Strs("parse_errors", a.errors).Msg("rule parse errors; not updating rules")
+		return errors.New("could not parse rules")
 	}
 
 	a.knownRoles = make([]string, 0)

--- a/internal/rules/analyzer.go
+++ b/internal/rules/analyzer.go
@@ -109,7 +109,6 @@ func (a *ViperConfigAnalyzer) UpdateFromConfigFile() error {
 	knownRoleSet := map[string]bool{}
 	var ruleNames []string
 
-	a.rules = nil
 	parsedRules := make([]Rule, 0, len(rules))
 	for _, curr := range rules {
 		r, err := curr.ToRule()
@@ -134,13 +133,9 @@ func (a *ViperConfigAnalyzer) UpdateFromConfigFile() error {
 		a.knownRoles = append(a.knownRoles, curr)
 	}
 
-	log.Info().Strs("loaded_rules", ruleNames).Strs("known_roles", a.knownRoles).Strs("errors", a.errors).Msg("loaded rules from files")
+	log.Info().Strs("loaded_rules", ruleNames).Strs("known_roles", a.knownRoles).Msg("loaded rules from files")
 
 	a.rules = parsedRules
-
-	if a.errors != nil {
-		return errors.New("there was an error parsing the rules")
-	}
 
 	a.lastUpdate = time.Now()
 	return nil

--- a/internal/rules/analyzer_test.go
+++ b/internal/rules/analyzer_test.go
@@ -47,7 +47,10 @@ rules:
       host_pattern: js.example.com
       path_pattern: '*.js'
       public: true
-
+    - name: Pihole internal
+      source_address: '192.168.0.0/16'
+      host_pattern: pihole.example.com
+      public: true
 `
 
 func TestViperConfigAnalyzer_UpdateFromConfigFile(t *testing.T) {
@@ -65,7 +68,7 @@ func TestViperConfigAnalyzer_UpdateFromConfigFile(t *testing.T) {
 		err = a.UpdateFromConfigFile()
 		require.NoError(t, err)
 
-		assert.Len(t, a.rules, 7)
+		assert.Len(t, a.rules, 8)
 
 		assert.Equal(t, "foo role", a.rules[0].Name)
 
@@ -204,7 +207,11 @@ func TestRuleRoundTrip(t *testing.T) {
 	err = v.ReadConfig(bytes.NewReader(marshalledRule))
 	require.NoError(t, err)
 
-	roundTrippedRule, err := New(v)
+	var rr rawRule
+	err = v.Unmarshal(&rr)
+	require.NoError(t, err)
+
+	roundTrippedRule, err := rr.ToRule()
 	require.NoError(t, err)
 
 	assert.Equal(t, r.Name, roundTrippedRule.Name)

--- a/internal/rules/analyzer_test.go
+++ b/internal/rules/analyzer_test.go
@@ -204,11 +204,7 @@ func TestRuleRoundTrip(t *testing.T) {
 	err = v.ReadConfig(bytes.NewReader(marshalledRule))
 	require.NoError(t, err)
 
-	var raw rawRule
-	err = v.Unmarshal(&raw)
-	require.NoError(t, err)
-
-	roundTrippedRule, err := raw.ToRule()
+	roundTrippedRule, err := New(v)
 	require.NoError(t, err)
 
 	assert.Equal(t, r.Name, roundTrippedRule.Name)

--- a/internal/rules/analyzer_test.go
+++ b/internal/rules/analyzer_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"net"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 const sampleRules = `
@@ -176,4 +178,45 @@ func TestViperConfigAnalyzer_MatchesRule(t *testing.T) {
 		})
 		assert.Nil(t, r)
 	})
+}
+
+func TestRuleRoundTrip(t *testing.T) {
+	_, sourceCIDR, err := net.ParseCIDR("10.0.0.0/8")
+	require.NoError(t, err)
+	r := &Rule{
+		Name:            "Some Test Rule",
+		SourceAddress:   sourceCIDR,
+		ProtocolPattern: new("https"),
+		HostPattern:     new("test.example.com"),
+		PathPattern:     new("/public/*"),
+		Timeout:         new(10 * time.Minute),
+		Public:          false,
+		PermittedRoles:  []string{"a", "b"},
+	}
+
+	parts := ruleConverter(r.toSerializableMap())
+
+	marshalledRule, err := yaml.Marshal(parts)
+	require.NoError(t, err)
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err = v.ReadConfig(bytes.NewReader(marshalledRule))
+	require.NoError(t, err)
+
+	var raw rawRule
+	err = v.Unmarshal(&raw)
+	require.NoError(t, err)
+
+	roundTrippedRule, err := raw.ToRule()
+	require.NoError(t, err)
+
+	assert.Equal(t, r.Name, roundTrippedRule.Name)
+	assert.Equal(t, r.SourceAddress, roundTrippedRule.SourceAddress)
+	assert.Equal(t, r.ProtocolPattern, roundTrippedRule.ProtocolPattern)
+	assert.Equal(t, r.HostPattern, roundTrippedRule.HostPattern)
+	assert.Equal(t, r.PathPattern, roundTrippedRule.PathPattern)
+	assert.Equal(t, r.Timeout, roundTrippedRule.Timeout)
+	assert.Equal(t, r.Public, roundTrippedRule.Public)
+	assert.Equal(t, r.PermittedRoles, roundTrippedRule.PermittedRoles)
 }

--- a/internal/rules/analyzer_test.go
+++ b/internal/rules/analyzer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const sampleRules = `
@@ -40,23 +41,29 @@ rules:
       host_pattern: test.example.com
       path_pattern: /
       public: true
+    - name: any JS
+      host_pattern: js.example.com
+      path_pattern: '*.js'
+      public: true
+
 `
 
 func TestViperConfigAnalyzer_UpdateFromConfigFile(t *testing.T) {
 	t.Run("happy case", func(t *testing.T) {
 		v := viper.New()
 		v.SetConfigType("yaml")
-		_ = v.ReadConfig(strings.NewReader(sampleRules))
+		err := v.ReadConfig(strings.NewReader(sampleRules))
+		require.NoError(t, err)
 
 		a := ViperConfigAnalyzer{
 			cfg: v,
 		}
 		assert.Empty(t, a.rules)
 
-		err := a.UpdateFromConfigFile()
-		assert.NoError(t, err)
+		err = a.UpdateFromConfigFile()
+		require.NoError(t, err)
 
-		assert.Len(t, a.rules, 6)
+		assert.Len(t, a.rules, 7)
 
 		assert.Equal(t, "foo role", a.rules[0].Name)
 
@@ -92,15 +99,16 @@ func TestViperConfigAnalyzer_MatchesRule(t *testing.T) {
 		v := viper.New()
 
 		v.SetConfigType("yaml")
-		_ = v.ReadConfig(strings.NewReader(sampleRules))
+		err := v.ReadConfig(strings.NewReader(sampleRules))
+		require.NoError(t, err)
 
 		a := ViperConfigAnalyzer{
 			cfg: v,
 		}
 		assert.Empty(t, a.rules)
 
-		err := a.UpdateFromConfigFile()
-		assert.NoError(t, err)
+		err = a.UpdateFromConfigFile()
+		require.NoError(t, err)
 
 		r := a.MatchesRule(&RequestInfo{
 			Method:     "GET",
@@ -131,6 +139,40 @@ func TestViperConfigAnalyzer_MatchesRule(t *testing.T) {
 			Host:       "aaaaa.example.com",
 			RequestURI: "/css/test.css",
 			SourceIP:   net.ParseIP("10.0.0.1"),
+		})
+		assert.Nil(t, r)
+	})
+
+	t.Run("do not match on query strings", func(t *testing.T) {
+		v := viper.New()
+
+		v.SetConfigType("yaml")
+		_ = v.ReadConfig(strings.NewReader(sampleRules))
+
+		a := ViperConfigAnalyzer{
+			cfg: v,
+		}
+		assert.Empty(t, a.rules)
+
+		err := a.UpdateFromConfigFile()
+		require.NoError(t, err)
+
+		r := a.MatchesRule(&RequestInfo{
+			Method:     "GET",
+			Protocol:   "http",
+			Host:       "js.example.com",
+			RequestURI: "/js/test.js",
+			SourceIP:   net.ParseIP("10.0.0.1"),
+		})
+		assert.NotNil(t, r)
+
+		r = a.MatchesRule(&RequestInfo{
+			Method:      "GET",
+			Protocol:    "http",
+			Host:        "js.example.com",
+			RequestURI:  "/admin/admin.html",
+			QueryString: "foo=something.js",
+			SourceIP:    net.ParseIP("10.0.0.1"),
 		})
 		assert.Nil(t, r)
 	})

--- a/internal/rules/normalize.go
+++ b/internal/rules/normalize.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 )
 
-func NormalizeURI(rawURI string) string {
-	p, query, hasQuery := strings.Cut(rawURI, "?")
+// NormalizeURI cleans up the URI by collapsing any sort of sneaky path escapes and also splits out the raw path
+// from the query string and each are returned separately
+func NormalizeURI(rawURI string) (string, string) {
+	p, query, _ := strings.Cut(rawURI, "?")
 
 	// if the normalization is malformed, just ignore it...won't match rules anyway
 	if dec, err := url.PathUnescape(p); err == nil {
@@ -25,11 +27,7 @@ func NormalizeURI(rawURI string) string {
 		p += "/"
 	}
 
-	if hasQuery {
-		return p + "?" + query
-	}
-
-	return p
+	return p, query
 }
 
 func NormalizeHost(h string) string {

--- a/internal/rules/normalize_test.go
+++ b/internal/rules/normalize_test.go
@@ -38,6 +38,7 @@ func TestNormalizeURI(t *testing.T) {
 		Name           string
 		Input          string
 		ExpectedOutput string
+		ExpectedQuery  string
 	}{
 		{
 			Name:           "basic test case (no query string)",
@@ -52,7 +53,8 @@ func TestNormalizeURI(t *testing.T) {
 		{
 			Name:           "basic test (with query string)",
 			Input:          "/admin/foo/bar?hello=world&something=another_thing",
-			ExpectedOutput: "/admin/foo/bar?hello=world&something=another_thing",
+			ExpectedOutput: "/admin/foo/bar",
+			ExpectedQuery:  "hello=world&something=another_thing",
 		},
 		{
 			Name:           "percent escape sequences",
@@ -72,7 +74,8 @@ func TestNormalizeURI(t *testing.T) {
 		{
 			Name:           "percent escape sequence with query (should not be escaped)",
 			Input:          "/%61dmin/foo?bar=ba%39",
-			ExpectedOutput: "/admin/foo?bar=ba%39",
+			ExpectedOutput: "/admin/foo",
+			ExpectedQuery:  "bar=ba%39",
 		},
 		{
 			Name:           "path collapse",
@@ -88,7 +91,9 @@ func TestNormalizeURI(t *testing.T) {
 
 	for _, curr := range tests {
 		t.Run(curr.Name, func(t *testing.T) {
-			assert.Equal(t, curr.ExpectedOutput, NormalizeURI(curr.Input))
+			path, query := NormalizeURI(curr.Input)
+			assert.Equal(t, curr.ExpectedOutput, path)
+			assert.Equal(t, curr.ExpectedQuery, query)
 		})
 	}
 }

--- a/internal/rules/request_info.go
+++ b/internal/rules/request_info.go
@@ -6,11 +6,12 @@ import (
 )
 
 type RequestInfo struct {
-	Method     string
-	Protocol   string
-	Host       string
-	RequestURI string
-	SourceIP   net.IP
+	Method      string
+	Protocol    string
+	Host        string
+	RequestURI  string
+	QueryString string
+	SourceIP    net.IP
 }
 
 func (ri *RequestInfo) Valid() bool {
@@ -22,6 +23,9 @@ func (ri *RequestInfo) GetURL() string {
 		Scheme: ri.Protocol,
 		Host:   ri.Host,
 		Path:   ri.RequestURI,
+	}
+	if ri.QueryString != "" {
+		dest.RawQuery = ri.QueryString
 	}
 	return dest.String()
 }

--- a/internal/rules/request_info.go
+++ b/internal/rules/request_info.go
@@ -20,12 +20,11 @@ func (ri *RequestInfo) Valid() bool {
 
 func (ri *RequestInfo) GetURL() string {
 	dest := url.URL{
-		Scheme: ri.Protocol,
-		Host:   ri.Host,
-		Path:   ri.RequestURI,
+		Scheme:   ri.Protocol,
+		Host:     ri.Host,
+		Path:     ri.RequestURI,
+		RawQuery: ri.QueryString,
 	}
-	if ri.QueryString != "" {
-		dest.RawQuery = ri.QueryString
-	}
+
 	return dest.String()
 }

--- a/internal/rules/request_info_test.go
+++ b/internal/rules/request_info_test.go
@@ -30,13 +30,28 @@ func TestRequestInfo_Valid(t *testing.T) {
 }
 
 func TestRequestInfo_GetURL(t *testing.T) {
-	ri := &RequestInfo{
-		Method:     http.MethodGet,
-		Protocol:   "https",
-		Host:       "example.com",
-		RequestURI: "/foo",
-		SourceIP:   net.ParseIP("127.0.0.1"),
-	}
+	t.Run("no query string", func(t *testing.T) {
+		ri := &RequestInfo{
+			Method:     http.MethodGet,
+			Protocol:   "https",
+			Host:       "example.com",
+			RequestURI: "/foo",
+			SourceIP:   net.ParseIP("127.0.0.1"),
+		}
 
-	assert.Equal(t, "https://example.com/foo", ri.GetURL())
+		assert.Equal(t, "https://example.com/foo", ri.GetURL())
+	})
+
+	t.Run("with query string", func(t *testing.T) {
+		ri := &RequestInfo{
+			Method:      http.MethodGet,
+			Protocol:    "https",
+			Host:        "example.com",
+			RequestURI:  "/foo",
+			QueryString: "baz=a&quix=b",
+			SourceIP:    net.ParseIP("127.0.0.1"),
+		}
+
+		assert.Equal(t, "https://example.com/foo?baz=a&quix=b", ri.GetURL())
+	})
 }

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -67,26 +67,35 @@ func New(v *viper.Viper) (*Rule, error) {
 // using the library `doublestar` could work here, but would break configs since `*` won't match across separators, but
 // ** will
 func internalMatch(pattern string, candidate string) bool {
-	for len(pattern) > 0 {
-		switch pattern[0] {
-		case '?':
-			// make sure we have at least one character we can consume
-			if len(candidate) == 0 {
-				return false
-			}
-		case '*':
-			return internalMatch(pattern[1:], candidate) || (len(candidate) > 0 && internalMatch(pattern, candidate[1:]))
-		default:
-			if len(candidate) == 0 || candidate[0] != pattern[0] {
-				return false
-			}
-		}
+	p := 0
+	c := 0
 
-		candidate = candidate[1:]
-		pattern = pattern[1:]
+	lastStar := -1
+	starMatches := 0
+
+	for c < len(candidate) {
+		if p < len(pattern) && pattern[p] == '*' {
+			lastStar = p
+			starMatches = c
+			p++
+		} else if p < len(pattern) && (pattern[p] == '?' || pattern[p] == candidate[c]) {
+			// match single character (either literal or ?)
+			p++
+			c++
+		} else if lastStar != -1 {
+			starMatches++
+			p = lastStar + 1
+			c = starMatches
+		} else {
+			return false
+		}
 	}
 
-	return len(candidate) == 0 && len(pattern) == 0
+	for p < len(pattern) && pattern[p] == '*' {
+		p++
+	}
+
+	return p == len(pattern)
 }
 
 func (r *Rule) Matches(ri *RequestInfo) bool {

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -3,8 +3,6 @@ package rules
 import (
 	"net"
 	"time"
-
-	"github.com/spf13/viper"
 )
 
 type Rule struct {
@@ -16,49 +14,6 @@ type Rule struct {
 	Timeout         *time.Duration
 	Public          bool
 	PermittedRoles  []string
-}
-
-func nonDefaultString(x string) *string {
-	if x != "" {
-		return &x
-	}
-	return nil
-}
-
-func New(v *viper.Viper) (*Rule, error) {
-	name := v.GetString("name")
-	source := v.GetString("source_address")
-	protocol := v.GetString("protocol_pattern")
-	host := v.GetString("host_pattern")
-	path := v.GetString("path_pattern")
-	timeout := v.GetDuration("timeout")
-	public := v.GetBool("public")
-	permittedRoles := v.GetStringSlice("permitted_roles")
-
-	var addr *net.IPNet
-	if source != "" {
-		_, n, err := net.ParseCIDR(source)
-		if err != nil {
-			return nil, err
-		}
-		addr = n
-	}
-
-	trueTimeout := &timeout
-	if timeout == 0 {
-		trueTimeout = nil
-	}
-
-	return &Rule{
-		Name:            name,
-		SourceAddress:   addr,
-		ProtocolPattern: nonDefaultString(protocol),
-		HostPattern:     nonDefaultString(host),
-		PathPattern:     nonDefaultString(path),
-		Timeout:         trueTimeout,
-		Public:          public,
-		PermittedRoles:  permittedRoles,
-	}, nil
 }
 
 // internalMatch matches input against patterns such as `/api/*`
@@ -107,24 +62,6 @@ func (r *Rule) Matches(ri *RequestInfo) bool {
 	pathMatch := r.PathPattern == nil || internalMatch(*r.PathPattern, ri.RequestURI)
 
 	return sourceMatch && protocolMatch && hostMatch && pathMatch
-}
-
-//nolint:unused // maybe we'll use this someday :)
-func (r *Rule) toRawRule() rawRule {
-	rr := rawRule{}
-	rr.Name = r.Name
-	if r.SourceAddress != nil {
-		rr.SourceAddress = new(r.SourceAddress.String())
-	}
-
-	rr.ProtocolPattern = r.ProtocolPattern
-	rr.HostPattern = r.HostPattern
-	rr.PathPattern = r.PathPattern
-
-	rr.Public = r.Public
-	rr.PermittedRoles = r.PermittedRoles
-
-	return rr
 }
 
 func (r *Rule) toSerializableMap() map[string]interface{} {

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -63,7 +63,7 @@ func New(v *viper.Viper) (*Rule, error) {
 
 // internalMatch matches input against patterns such as `/api/*`
 // a * in a pattern matches many characters. A ? matches a single character. We can not use path.Match here because
-// we want * to match across separators (e.g. `/api/*` would match `/api/foo` but not `/api/v1/foo. Note for future self
+// we want * to match across separators (e.g. `/api/*` would match `/api/foo` but not `/api/v1/foo). Note for future self
 // using the library `doublestar` could work here, but would break configs since `*` won't match across separators, but
 // ** will
 func internalMatch(pattern string, candidate string) bool {

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -27,13 +27,13 @@ func nonDefaultString(x string) *string {
 
 func New(v *viper.Viper) (*Rule, error) {
 	name := v.GetString("name")
-	source := v.GetString("source")
+	source := v.GetString("source_address")
 	protocol := v.GetString("protocol_pattern")
 	host := v.GetString("host_pattern")
 	path := v.GetString("path_pattern")
 	timeout := v.GetDuration("timeout")
 	public := v.GetBool("public")
-	permittedRoles := v.GetStringSlice("roles")
+	permittedRoles := v.GetStringSlice("permitted_roles")
 
 	var addr *net.IPNet
 	if source != "" {

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -151,7 +151,7 @@ func (r *Rule) toSerializableMap() map[string]interface{} {
 	}
 
 	if r.Timeout != nil {
-		m["timeout"] = *r.Timeout
+		m["timeout"] = (*r.Timeout).String()
 	}
 
 	return m

--- a/internal/rules/rule_test.go
+++ b/internal/rules/rule_test.go
@@ -8,9 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInternalMatch(t *testing.T) {
@@ -44,62 +42,6 @@ func TestInternalMatch(t *testing.T) {
 	assert.False(t, internalMatch("*a*a*a*a*a*a*a*a*a*b", strings.Repeat("a", 50)))
 	assert.True(t, internalMatch(strings.Repeat("*a", 30), strings.Repeat("a", 50)))
 
-}
-
-func TestRule_New(t *testing.T) {
-	t.Run("fully defined rule", func(t *testing.T) {
-		v := viper.New()
-		v.Set("name", "test rule")
-		v.Set("source_address", "192.168.0.0/16")
-		v.Set("protocol_pattern", "https")
-		v.Set("host_pattern", "example.com")
-		v.Set("path_pattern", "/foo")
-		v.Set("timeout", "5m")
-		v.Set("public", false)
-		v.Set("permitted_roles", []string{"a", "b"})
-
-		r, err := New(v)
-		require.NoError(t, err)
-
-		_, s, _ := net.ParseCIDR("192.168.0.0/16")
-
-		assert.Equal(t, "test rule", r.Name)
-		assert.Equal(t, s, r.SourceAddress)
-		assert.Equal(t, "https", *r.ProtocolPattern)
-		assert.Equal(t, "example.com", *r.HostPattern)
-		assert.Equal(t, "/foo", *r.PathPattern)
-		assert.Equal(t, 5*time.Minute, *r.Timeout)
-		assert.Equal(t, false, r.Public)
-		assert.Equal(t, []string{"a", "b"}, r.PermittedRoles)
-	})
-
-	t.Run("error on invalid CIDR", func(t *testing.T) {
-		v := viper.New()
-		v.Set("name", "test rule")
-		v.Set("source_address", "aaaaaaaaa")
-		v.Set("host_pattern", "example.com")
-		v.Set("path_pattern", "/foo")
-
-		r, err := New(v)
-		assert.Nil(t, r)
-		assert.Error(t, err)
-	})
-
-	t.Run("without timeout", func(t *testing.T) {
-		v := viper.New()
-		v.Set("name", "test rule")
-		v.Set("host_pattern", "example.com")
-
-		r, err := New(v)
-		assert.NoError(t, err)
-
-		assert.Equal(t, "test rule", r.Name)
-		assert.Equal(t, "example.com", *r.HostPattern)
-		assert.Empty(t, r.PathPattern)
-		assert.Empty(t, r.ProtocolPattern)
-		assert.Empty(t, r.SourceAddress)
-		assert.Empty(t, r.Timeout)
-	})
 }
 
 func TestRule_Matches(t *testing.T) {
@@ -144,55 +86,6 @@ func TestRule_Matches(t *testing.T) {
 		r.PathPattern = &requestURI
 		r.SourceAddress = otherNetwork
 		assert.False(t, r.Matches(ri))
-	})
-
-}
-
-func TestRule_toRawRule(t *testing.T) {
-	_, internalNetwork, _ := net.ParseCIDR("192.168.0.0/16")
-	protocol := "https"
-	host := "example.com"
-	requestURI := "/foo"
-
-	t.Run("completely defined rule", func(t *testing.T) {
-		r := &Rule{
-			Name:            "test rule",
-			SourceAddress:   internalNetwork,
-			ProtocolPattern: &protocol,
-			HostPattern:     &host,
-			PathPattern:     &requestURI,
-			Public:          false,
-			PermittedRoles:  []string{"a", "b"},
-		}
-
-		rr := r.toRawRule()
-
-		assert.Equal(t, "test rule", rr.Name)
-		assert.Equal(t, "192.168.0.0/16", *rr.SourceAddress)
-		assert.Equal(t, "https", *rr.ProtocolPattern)
-		assert.Equal(t, "example.com", *rr.HostPattern)
-		assert.Equal(t, "/foo", *rr.PathPattern)
-		assert.Equal(t, false, rr.Public)
-		assert.Equal(t, []string{"a", "b"}, rr.PermittedRoles)
-	})
-
-	t.Run("some things left undefined", func(t *testing.T) {
-		r := &Rule{
-			Name:           "a second rule",
-			HostPattern:    &host,
-			Public:         false,
-			PermittedRoles: []string{"a"},
-		}
-
-		rr := r.toRawRule()
-
-		assert.Equal(t, "a second rule", rr.Name)
-		assert.Nil(t, rr.SourceAddress)
-		assert.Nil(t, rr.ProtocolPattern)
-		assert.Equal(t, "example.com", *rr.HostPattern)
-		assert.Nil(t, rr.PathPattern)
-		assert.Equal(t, false, rr.Public)
-		assert.Equal(t, []string{"a"}, rr.PermittedRoles)
 	})
 
 }

--- a/internal/rules/rule_test.go
+++ b/internal/rules/rule_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,25 @@ func TestInternalMatch(t *testing.T) {
 	assert.True(t, internalMatch("a??", "abc"))
 
 	assert.False(t, internalMatch("a??", "ab"))
+
+	assert.True(t, internalMatch("/api/*/users", "/api/v2/users"))
+	assert.True(t, internalMatch("/api/*", "/api/v2/users"))
+	assert.True(t, internalMatch("/static/*/*.js", "/static/vendor/js/script.js"))
+
+	assert.False(t, internalMatch("/admin/*", "/public/index.html"))
+	assert.False(t, internalMatch("/api/v1/*", "/api/v2/ping"))
+
+	assert.True(t, internalMatch("", ""))
+	assert.True(t, internalMatch("*", ""))
+	assert.True(t, internalMatch("*", strings.Repeat("a", 50)))
+	assert.True(t, internalMatch(strings.Repeat("?", 50), strings.Repeat("a", 50)))
+	assert.True(t, internalMatch(strings.Repeat("*", 50), strings.Repeat("a", 50)))
+	assert.True(t, internalMatch(strings.Repeat("*", 49), strings.Repeat("a", 50)))
+
+	assert.True(t, internalMatch("*a*a*a*a*a*a*a*a*a*", strings.Repeat("a", 50)))
+	assert.False(t, internalMatch("*a*a*a*a*a*a*a*a*a*b", strings.Repeat("a", 50)))
+	assert.True(t, internalMatch(strings.Repeat("*a", 30), strings.Repeat("a", 50)))
+
 }
 
 func TestRule_New(t *testing.T) {

--- a/internal/rules/rule_test.go
+++ b/internal/rules/rule_test.go
@@ -50,13 +50,13 @@ func TestRule_New(t *testing.T) {
 	t.Run("fully defined rule", func(t *testing.T) {
 		v := viper.New()
 		v.Set("name", "test rule")
-		v.Set("source", "192.168.0.0/16")
+		v.Set("source_address", "192.168.0.0/16")
 		v.Set("protocol_pattern", "https")
 		v.Set("host_pattern", "example.com")
 		v.Set("path_pattern", "/foo")
 		v.Set("timeout", "5m")
 		v.Set("public", false)
-		v.Set("roles", []string{"a", "b"})
+		v.Set("permitted_roles", []string{"a", "b"})
 
 		r, err := New(v)
 		require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestRule_New(t *testing.T) {
 	t.Run("error on invalid CIDR", func(t *testing.T) {
 		v := viper.New()
 		v.Set("name", "test rule")
-		v.Set("source", "aaaaaaaaa")
+		v.Set("source_address", "aaaaaaaaa")
 		v.Set("host_pattern", "example.com")
 		v.Set("path_pattern", "/foo")
 
@@ -267,7 +267,7 @@ func TestSerializationFieldsAccountedFor(t *testing.T) {
 		}
 
 		key, _, _ := strings.Cut(tag, ",") // omit ... uh ... ,omitempty
-		if !assert.NotEmptyf(t, tag, "field %s has empty mapstructure key", field.Name) {
+		if !assert.NotEmptyf(t, key, "field %s has empty mapstructure key", field.Name) {
 			continue
 		}
 

--- a/internal/rules/rule_test.go
+++ b/internal/rules/rule_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"net"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -222,7 +223,7 @@ func TestRule_toSerializableMap(t *testing.T) {
 		assert.Equal(t, "https", rr["protocol_pattern"])
 		assert.Equal(t, "example.com", rr["host_pattern"])
 		assert.Equal(t, "/foo", rr["path_pattern"])
-		assert.Equal(t, 5*time.Second, rr["timeout"])
+		assert.Equal(t, "5s", rr["timeout"])
 	})
 
 	t.Run("some things left undefined", func(t *testing.T) {
@@ -242,4 +243,35 @@ func TestRule_toSerializableMap(t *testing.T) {
 		assert.Nil(t, rr["path_pattern"])
 		assert.Nil(t, rr["timeout"])
 	})
+}
+
+func fieldOrderSet() map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, curr := range ruleFieldOrder {
+		m[curr] = struct{}{}
+	}
+
+	return m
+}
+
+func TestSerializationFieldsAccountedFor(t *testing.T) {
+	fields := fieldOrderSet()
+
+	rt := reflect.TypeFor[rawRule]()
+	for i := range rt.NumField() {
+		field := rt.Field(i)
+
+		tag := field.Tag.Get("mapstructure")
+		if !assert.NotEmptyf(t, tag, "field %s has no mapstructure tag", field.Name) {
+			continue
+		}
+
+		key, _, _ := strings.Cut(tag, ",") // omit ... uh ... ,omitempty
+		if !assert.NotEmptyf(t, tag, "field %s has empty mapstructure key", field.Name) {
+			continue
+		}
+
+		_, fieldExists := fields[key]
+		assert.Truef(t, fieldExists, "rawRule field %s (key %q) is missing from ruleFieldOrder", field.Name, key)
+	}
 }


### PR DESCRIPTION
- remove query string from path matching (THIS MAY BREAK CONFIGS)
- rewrite string matching to be much more performant (especially against adversarial patterns)
- clean up rule serialization and remove dead code