### PR TITLE
make the matcher work with unicode

### DIFF
--- a/internal/rules/matcher.go
+++ b/internal/rules/matcher.go
@@ -1,0 +1,95 @@
+package rules
+
+import "unicode/utf8"
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// internalMatch matches input against patterns such as `/api/*`
+// a * in a pattern matches many characters. A ? matches a single character. We can not use path.Match here because
+// we want * to match across separators (e.g. `/api/*` would match `/api/foo` but not `/api/v1/foo). Note for future self
+// using the library `doublestar` could work here, but would break configs since `*` won't match across separators, but
+// ** will
+//
+// note that there are two versions of this function, one that is optimized for pure-ASCII strings and one that can
+// handle the wider characters of unicode. We do a simple check to see if both the candidate and pattern are pure ascii
+// and if so, we do the faster ASCII version, otherwise fall back to the unicode version. Based on benchmarking, the
+// ASCII version is about 1.7-2.4x as fast as the unicode one
+func internalMatch(pattern string, candidate string) bool {
+	if isASCII(pattern) && isASCII(candidate) {
+		return internalMatchASCII(pattern, candidate)
+	}
+
+	return internalMatchUnicode(pattern, candidate)
+}
+
+func internalMatchASCII(pattern string, candidate string) bool {
+	p := 0
+	c := 0
+
+	lastStar := -1
+	starMatches := 0
+
+	for c < len(candidate) {
+		if p < len(pattern) && pattern[p] == '*' {
+			lastStar = p
+			starMatches = c
+			p++
+		} else if p < len(pattern) && (pattern[p] == '?' || pattern[p] == candidate[c]) {
+			p++
+			c++
+		} else if lastStar != -1 {
+			starMatches++
+			p = lastStar + 1
+			c = starMatches
+		} else {
+			return false
+		}
+	}
+
+	for p < len(pattern) && pattern[p] == '*' {
+		p++
+	}
+
+	return p == len(pattern)
+}
+
+func internalMatchUnicode(pattern string, candidate string) bool {
+	patternRunes := []rune(pattern)
+	candidateRunes := []rune(candidate)
+
+	p := 0
+	c := 0
+
+	lastStar := -1
+	starMatches := 0
+
+	for c < len(candidateRunes) {
+		if p < len(patternRunes) && patternRunes[p] == '*' {
+			lastStar = p
+			starMatches = c
+			p++
+		} else if p < len(patternRunes) && (patternRunes[p] == '?' || patternRunes[p] == candidateRunes[c]) {
+			p++
+			c++
+		} else if lastStar != -1 {
+			starMatches++
+			p = lastStar + 1
+			c = starMatches
+		} else {
+			return false
+		}
+	}
+
+	for p < len(patternRunes) && patternRunes[p] == '*' {
+		p++
+	}
+
+	return p == len(patternRunes)
+}

--- a/internal/rules/matcher_test.go
+++ b/internal/rules/matcher_test.go
@@ -1,0 +1,121 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInternalMatch(t *testing.T) {
+	groups := map[string][]struct {
+		pattern   string
+		candidate string
+		matches   bool
+	}{
+		"easy cases": {
+			{"abc", "abc", true},
+			{"a", "a", true},
+		},
+		"trailing stars": {
+			{"*", "abcdefg", true},
+			{"a*", "abc", true},
+			{"a*", "babc", false},
+		},
+		"question marks": {
+			{"a?c", "abc", true},
+			{"a??", "abc", true},
+			{"a??", "ab", false},
+		},
+		"empty edges": {
+			{"", "", true},
+			{"*", "", true},
+			{"", "abc", false},
+			{"abc", "", false},
+		},
+		"length mismatches": {
+			{"abc", "abcd", false},
+			{"abcd", "abc", false},
+		},
+		"star matches zero characters": {
+			{"a*", "a", true},
+			{"*abc", "abc", true},
+			{"a*b*c", "abc", true},
+			{"***", "", true},
+			{"a**b", "ab", true},
+			{"a**", "a", true},
+		},
+		"? edge cases": {
+			{"a?", "a", false},
+			{"?", "", false},
+			{"a?b", "a/b", true},
+			{"?*", "", false},
+		},
+		"backtracking": {
+			{"*abc", "abcabc", true},
+			{"*.js", "script.js", true},
+			{"*.js", "script.jsx", false},
+		},
+		"paths": {
+			{"/api/*/users", "/api/v2/users", true},
+			{"/api/*", "/api/v2/users", true},
+			{"/static/*/*.js", "/static/vendor/js/script.js", true},
+			{"/admin/*", "/public/index.html", false},
+			{"/api/v1/*", "/api/v2/ping", false},
+		},
+		"long ones": {
+			{strings.Repeat("?", 50), strings.Repeat("a", 50), true},
+			{strings.Repeat("*", 50), strings.Repeat("a", 50), true},
+			{strings.Repeat("*", 49), strings.Repeat("a", 50), true},
+		},
+		"adversarial backtracking": {
+			{"*a*a*a*a*a*a*a*a*a*", strings.Repeat("a", 50), true},
+			{"*a*a*a*a*a*a*a*a*a*b", strings.Repeat("a", 50), false},
+			{strings.Repeat("*a", 30), strings.Repeat("a", 50), true},
+		},
+		"unicode stuff": {
+			{"*", "🍔", true},
+			{"hamburger?", "hamburger🍔", true},
+			{"caf?", "café", true},
+			{"caf??", "café", false},
+			{"caf*", "café", true},
+		},
+	}
+
+	for name, cases := range groups {
+		t.Run(name, func(t *testing.T) {
+			for _, c := range cases {
+				t.Run(fmt.Sprintf("%q vs %q", c.pattern, c.candidate), func(t *testing.T) {
+					assert.Equal(t, c.matches, internalMatch(c.pattern, c.candidate))
+					assert.Equal(t, c.matches, internalMatchUnicode(c.pattern, c.candidate)) // make sure the implementations don't drift
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkInternalMatch(b *testing.B) {
+	cases := []struct {
+		Name      string
+		Pattern   string
+		Candidate string
+	}{
+		{"simple_path", "/api/*", "/api/v2/users"},
+		{"star_in_middle", "/static/*/*.js", "/static/vendor/js/script.js"},
+		{"no_match", "/admin/*", "/public/index.html"},
+		{"adversarial", strings.Repeat("*a", 30), strings.Repeat("a", 50) + "b"},
+		{"unicode", "caf*", "café"},
+		{"long_candidate_string", "*", strings.Repeat("a", 512)},
+		{"long_unicode", "*", strings.Repeat("á", 50)},
+	}
+
+	for _, curr := range cases {
+		b.Run(curr.Name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				internalMatch(curr.Pattern, curr.Candidate)
+			}
+		})
+	}
+}

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -16,43 +16,6 @@ type Rule struct {
 	PermittedRoles  []string
 }
 
-// internalMatch matches input against patterns such as `/api/*`
-// a * in a pattern matches many characters. A ? matches a single character. We can not use path.Match here because
-// we want * to match across separators (e.g. `/api/*` would match `/api/foo` but not `/api/v1/foo). Note for future self
-// using the library `doublestar` could work here, but would break configs since `*` won't match across separators, but
-// ** will
-func internalMatch(pattern string, candidate string) bool {
-	p := 0
-	c := 0
-
-	lastStar := -1
-	starMatches := 0
-
-	for c < len(candidate) {
-		if p < len(pattern) && pattern[p] == '*' {
-			lastStar = p
-			starMatches = c
-			p++
-		} else if p < len(pattern) && (pattern[p] == '?' || pattern[p] == candidate[c]) {
-			// match single character (either literal or ?)
-			p++
-			c++
-		} else if lastStar != -1 {
-			starMatches++
-			p = lastStar + 1
-			c = starMatches
-		} else {
-			return false
-		}
-	}
-
-	for p < len(pattern) && pattern[p] == '*' {
-		p++
-	}
-
-	return p == len(pattern)
-}
-
 func (r *Rule) Matches(ri *RequestInfo) bool {
 	// OPTIMIZE: we can return early if a match does not happen for a given rule
 

--- a/internal/rules/rule_test.go
+++ b/internal/rules/rule_test.go
@@ -11,39 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInternalMatch(t *testing.T) {
-	assert.True(t, internalMatch("abc", "abc"))
-	assert.True(t, internalMatch("a", "a"))
-
-	assert.True(t, internalMatch("*", "abcdefg"))
-	assert.True(t, internalMatch("a*", "abc"))
-	assert.False(t, internalMatch("a*", "babc"))
-
-	assert.True(t, internalMatch("a?c", "abc"))
-	assert.True(t, internalMatch("a??", "abc"))
-
-	assert.False(t, internalMatch("a??", "ab"))
-
-	assert.True(t, internalMatch("/api/*/users", "/api/v2/users"))
-	assert.True(t, internalMatch("/api/*", "/api/v2/users"))
-	assert.True(t, internalMatch("/static/*/*.js", "/static/vendor/js/script.js"))
-
-	assert.False(t, internalMatch("/admin/*", "/public/index.html"))
-	assert.False(t, internalMatch("/api/v1/*", "/api/v2/ping"))
-
-	assert.True(t, internalMatch("", ""))
-	assert.True(t, internalMatch("*", ""))
-	assert.True(t, internalMatch("*", strings.Repeat("a", 50)))
-	assert.True(t, internalMatch(strings.Repeat("?", 50), strings.Repeat("a", 50)))
-	assert.True(t, internalMatch(strings.Repeat("*", 50), strings.Repeat("a", 50)))
-	assert.True(t, internalMatch(strings.Repeat("*", 49), strings.Repeat("a", 50)))
-
-	assert.True(t, internalMatch("*a*a*a*a*a*a*a*a*a*", strings.Repeat("a", 50)))
-	assert.False(t, internalMatch("*a*a*a*a*a*a*a*a*a*b", strings.Repeat("a", 50)))
-	assert.True(t, internalMatch(strings.Repeat("*a", 30), strings.Repeat("a", 50)))
-
-}
-
 func TestRule_Matches(t *testing.T) {
 	ri := &RequestInfo{
 		Method:     http.MethodGet,


### PR DESCRIPTION
Unicode support for rule matching...we keep a special, optimized ASCII version around of the matcher since it's faster and fallback to the slower Unicode one if needed